### PR TITLE
Update package.json, add peerDep node v18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
 		"turbo": "^1.10.12",
 		"typescript": "^5.1.6"
 	},
+	"peerDependencies": {
+		"node": ">=18.3"
+	},
 	"name": "rubric",
 	"packageManager": "yarn@1.22.19",
 	"private": true,


### PR DESCRIPTION
util.parseArgs was added to node.js in v18.3.0. This peer dependency is accurate.